### PR TITLE
Fix:  UnmarshalCollectionBody does not return all errors

### DIFF
--- a/azuredevops/client.go
+++ b/azuredevops/client.go
@@ -315,6 +315,9 @@ func (client *Client) UnmarshalCollectionBody(response *http.Response, v interfa
 
 		body = trimByteOrderMark(body)
 		err = client.UnmarshalCollectionJson(body, v)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR contains a fix for UnmarshalCollectionBody, so that all (internal) errors are returned by the function to the caller.