### PR TITLE
return http statusCode within WrapperError

### DIFF
--- a/azuredevops/client.go
+++ b/azuredevops/client.go
@@ -381,6 +381,7 @@ func (client *Client) UnwrapError(response *http.Response) (err error) {
 
 	var wrappedError WrappedError
 	err = json.Unmarshal(body, &wrappedError)
+	wrappedError.StatusCode = &response.StatusCode
 	if err != nil {
 		return err
 	}
@@ -389,10 +390,9 @@ func (client *Client) UnwrapError(response *http.Response) (err error) {
 		var wrappedImproperError WrappedImproperError
 		err = json.Unmarshal(body, &wrappedImproperError)
 		if err == nil && wrappedImproperError.Value != nil && wrappedImproperError.Value.Message != nil {
-			statusCode := response.StatusCode
 			return &WrappedError{
 				Message:    wrappedImproperError.Value.Message,
-				StatusCode: &statusCode,
+				StatusCode: &response.StatusCode,
 			}
 		}
 	}


### PR DESCRIPTION
@tedchamb 
When the service with the error message responds, an HTTP status code is returned within "WrapperError". In some cases, HTTP status codes can help handle error responses. 
solve issue #54 