### PR TITLE
workaround for issue #59, support "2006-01-02T15:04:05.999999999" time format

### DIFF
--- a/azuredevops/models.go
+++ b/azuredevops/models.go
@@ -6,6 +6,7 @@ package azuredevops
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -63,14 +64,26 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	t2 := time.Time{}
 	err := json.Unmarshal(b, &t2)
 
-	// ignore errors for 0001-01-01T00:00:00 dates. The Azure DevOps service
-	// returns default dates in a format that is invalid for a time.Time. The
-	// correct value would have a 'z' at the end to represent utc. We are going
-	// to ignore this error, and set the value to the default time.Time value.
-	// https://github.com/microsoft/azure-devops-go-api/issues/17
 	if err != nil {
-		if parseError, ok := err.(*time.ParseError); ok && parseError.Value == "\"0001-01-01T00:00:00\"" {
-			err = nil
+		parseError, ok := err.(*time.ParseError)
+		if ok {
+			if parseError.Value == "\"0001-01-01T00:00:00\"" {
+				// ignore errors for 0001-01-01T00:00:00 dates. The Azure DevOps service
+				// returns default dates in a format that is invalid for a time.Time. The
+				// correct value would have a 'z' at the end to represent utc. We are going
+				// to ignore this error, and set the value to the default time.Time value.
+				// https://github.com/microsoft/azure-devops-go-api/issues/17
+				err = nil
+			} else {
+				// workaround for bug https://github.com/microsoft/azure-devops-go-api/issues/59
+				// policy.CreatePolicyConfiguration returns an invalid date format of form
+				// "2006-01-02T15:04:05.999999999"
+				var innerError error
+				t2, innerError = time.Parse("2006-01-02T15:04:05.999999999", strings.Trim(parseError.Value, "\""))
+				if innerError == nil {
+					err = nil
+				}
+			}
 		}
 	}
 

--- a/azuredevops/models_test.go
+++ b/azuredevops/models_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestModels_Unmarshal_Time(t *testing.T) {
-	text := []byte("{\"id\":\"d221ad31-3a7b-52c0-b71d-b255b1ff63ba\",\"time1\":\"0001-01-01T00:00:00\",\"time2\":\"2019-09-01T00:07:26Z\",\"int\":10,\"string\":\"test string\"}")
+	text := []byte("{\"id\":\"d221ad31-3a7b-52c0-b71d-b255b1ff63ba\",\"time1\":\"0001-01-01T00:00:00\",\"time2\":\"2019-09-01T00:07:26Z\",\"time3\":\"2020-05-16T20:55:32.0116793\",\"int\":10,\"string\":\"test string\"}")
 	testModel := TestModel{}
 
 	testModel.Time1 = &Time{}
@@ -30,7 +30,13 @@ func TestModels_Unmarshal_Time(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if testModel.Time2.Time != parsedTime {
-		t.Errorf("Expected time: %v  Actual time: %v", parsedTime, testModel.Time1.Time)
+		t.Errorf("Expected time: %v  Actual time: %v", parsedTime, testModel.Time2.Time)
+	}
+
+	// Test workaround for issue #59 https://github.com/microsoft/azure-devops-go-api/issues/59
+	parsedTime59, err := time.Parse("2006-01-02T15:04:05.999999999", "2020-05-16T20:55:32.0116793")
+	if testModel.Time3.Time != parsedTime59 {
+		t.Errorf("Expected time: %v  Actual time: %v", parsedTime59, testModel.Time3.Time)
 	}
 }
 
@@ -62,6 +68,7 @@ type TestModel struct {
 	Id     *uuid.UUID `json:"id,omitempty"`
 	Time1  *Time      `json:"time1,omitempty"`
 	Time2  *Time      `json:"time2,omitempty"`
+	Time3  *Time      `json:"time3,omitempty"`
 	Int    *uint64    `json:"int,omitempty"`
 	String *string    `json:"string,omitempty"`
 }


### PR DESCRIPTION
workaround for issue #59, support "2006-01-02T15:04:05.999999999" time format