### PR TITLE
feat: support for options for default client and git client

### DIFF
--- a/azuredevops/client_options.go
+++ b/azuredevops/client_options.go
@@ -1,0 +1,32 @@
+package azuredevops
+
+import (
+	"log"
+	"net/http"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+)
+
+// ClientOptionFunc can be used customize a new AzureDevops API client.
+type ClientOptionFunc func(*Client)
+
+// WithCustomRetry can be used to configure a custom retry policy.
+func WithCustomRetry(checkRetry retryablehttp.CheckRetry) ClientOptionFunc {
+	return func(c *Client) {
+		c.client.CheckRetry = checkRetry
+	}
+}
+
+// WithHTTPClient can be used to configure a custom HTTP client.
+func WithHTTPClient(httpClient *http.Client) ClientOptionFunc {
+	return func(c *Client) {
+		c.client.HTTPClient = httpClient
+	}
+}
+
+// WithCustomLogger allows you to specify a custom logger.
+func WithCustomLogger(logger *log.Logger) ClientOptionFunc {
+	return func(c *Client) {
+		c.logger = logger
+	}
+}

--- a/azuredevops/connection.go
+++ b/azuredevops/connection.go
@@ -6,10 +6,11 @@ package azuredevops
 import (
 	"context"
 	"encoding/base64"
-	"github.com/google/uuid"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Creates a new Azure DevOps connection instance using a personal access token.
@@ -53,26 +54,26 @@ func normalizeUrl(url string) string {
 	return strings.ToLower(strings.TrimRight(url, "/"))
 }
 
-func (connection *Connection) GetClientByResourceAreaId(ctx context.Context, resourceAreaID uuid.UUID) (*Client, error) {
+func (connection *Connection) GetClientByResourceAreaId(ctx context.Context, resourceAreaID uuid.UUID, options ...ClientOptionFunc) (*Client, error) {
 	resourceAreaInfo, err := connection.getResourceAreaInfo(ctx, resourceAreaID)
 	if err != nil {
 		return nil, err
 	}
 	var client *Client
 	if resourceAreaInfo != nil {
-		client = connection.GetClientByUrl(*resourceAreaInfo.LocationUrl)
+		client = connection.GetClientByUrl(*resourceAreaInfo.LocationUrl, options...)
 	} else {
 		// resourceAreaInfo will be nil for on prem servers
-		client = connection.GetClientByUrl(connection.BaseUrl)
+		client = connection.GetClientByUrl(connection.BaseUrl, options...)
 	}
 	return client, nil
 }
 
-func (connection *Connection) GetClientByUrl(baseUrl string) *Client {
+func (connection *Connection) GetClientByUrl(baseUrl string, options ...ClientOptionFunc) *Client {
 	normalizedUrl := normalizeUrl(baseUrl)
 	azureDevOpsClient, ok := connection.getClientCacheEntry(normalizedUrl)
 	if !ok {
-		azureDevOpsClient = NewClient(connection, normalizedUrl)
+		azureDevOpsClient = NewClientWithOptions(connection, normalizedUrl, options...)
 		connection.setClientCacheEntry(normalizedUrl, azureDevOpsClient)
 	}
 	return azureDevOpsClient

--- a/azuredevops/git/client.go
+++ b/azuredevops/git/client.go
@@ -12,15 +12,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
 	"github.com/google/uuid"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/core"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/policy"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
-	"io"
-	"net/http"
-	"net/url"
-	"strconv"
 )
 
 var ResourceAreaId, _ = uuid.Parse("4e080c62-fa21-4fbc-8fef-2a10a2b38049")
@@ -265,7 +266,11 @@ type ClientImpl struct {
 }
 
 func NewClient(ctx context.Context, connection *azuredevops.Connection) (Client, error) {
-	client, err := connection.GetClientByResourceAreaId(ctx, ResourceAreaId)
+	return NewClientWithOptions(ctx, connection)
+}
+
+func NewClientWithOptions(ctx context.Context, connection *azuredevops.Connection, options ...azuredevops.ClientOptionFunc) (Client, error) {
+	client, err := connection.GetClientByResourceAreaId(ctx, ResourceAreaId, options)
 	if err != nil {
 		return nil, err
 	}

--- a/azuredevops/go.mod
+++ b/azuredevops/go.mod
@@ -2,4 +2,7 @@ module github.com/microsoft/azure-devops-go-api/azuredevops
 
 go 1.12
 
-require github.com/google/uuid v1.1.1
+require (
+	github.com/google/uuid v1.1.1
+	github.com/hashicorp/go-retryablehttp v0.6.6
+)

--- a/azuredevops/go.sum
+++ b/azuredevops/go.sum
@@ -1,2 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
+github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Still a WIP.

Initial support for custom http clients and options in clients. Currently only support for the git client has been added.

Retryable functionality heavily based on #49 
