### PR TITLE
Add method to update endpoint permissions for all pipelines

### DIFF
--- a/azuredevops/pipelines/models.go
+++ b/azuredevops/pipelines/models.go
@@ -210,3 +210,28 @@ type Variable struct {
 	IsSecret *bool   `json:"isSecret,omitempty"`
 	Value    *string `json:"value,omitempty"`
 }
+
+type Resource struct {
+	Id   *string `json:"id,omitempty"`
+	Type *string `json:"type,omitempty"`
+	Name *string `json:"name,omitempty"`
+}
+
+type Member struct {
+	Id          *string `json:"id,omitempty"`
+	DisplayName *string `json:"displayName,omitempty"`
+	UniqueName  *string `json:"uniqueName,omitempty"`
+	Descriptor  *string `json:"descriptor,omitempty"`
+}
+
+type ResourcePermissions struct {
+	Authorized   *bool             `json:"authorized,omitempty"`
+	AuthorizedBy *Member           `json:"authorizedBy,omitempty"`
+	AuthorizedOn *azuredevops.Time `json:"authorizedOn,omitempty"`
+}
+
+type PipelineResourcePermissions struct {
+	Resource     *Resource            `json:"resource,omitempty"`
+	Pipelines    *[]int               `json:"pipelines,omitempty"`
+	AllPipelines *ResourcePermissions `json:"allPipelines,omitempty"`
+}


### PR DESCRIPTION
So that all pipelines can be granted or denied access to
service endpoints.

Issue: #82 

Example of use:

```go
        // Create a client to interact with the Pipelines area
	pipelineClient := pipelines.NewClient(ctx, connection)
	if err != nil {
		log.Fatal(err)
	}
	resource_id := "9948edhu-b56d-4890-b0a6-0a980b1d8904"
	project := "testProject"
	authorized := true
	args := pipelines.UpdateEndpointPermissionsArgs{
		PermissionsParameters: &pipelines.PipelineResourcePermissions{
			Resource:     &pipelines.Resource{Id: &resource_id, Type: nil},
			AllPipelines: &pipelines.ResourcePermissions{Authorized: &authorized},
			Pipelines:    nil,
		},
		Project: &project,
	}
	permissionResponse, err := pipelineClient.UpdateEndpointPermissions(ctx, args)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("%v", *permissionResponse.AllPipelines.Authorized)
```