### PR TITLE
Exposing TLS Configuration via Connection

### DIFF
--- a/azuredevops/client.go
+++ b/azuredevops/client.go
@@ -45,7 +45,7 @@ var apiResourceLocationCache = make(map[string]*map[uuid.UUID]ApiResourceLocatio
 var apiResourceLocationCacheLock = sync.RWMutex{}
 
 var version = "1.1.0-b3" // todo: remove hardcoded version
-var versionSuffix = ""
+var versionSuffix = " (dev)"
 
 // Base user agent string.  The UserAgent set on the connection will be appended to this.
 var baseUserAgent = "go/" + runtime.Version() + " (" + runtime.GOOS + " " + runtime.GOARCH + ") azure-devops-go-api/" + version + versionSuffix

--- a/azuredevops/connection.go
+++ b/azuredevops/connection.go
@@ -5,11 +5,13 @@ package azuredevops
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
-	"github.com/google/uuid"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Creates a new Azure DevOps connection instance using a personal access token.
@@ -38,6 +40,7 @@ type Connection struct {
 	SuppressFedAuthRedirect bool
 	ForceMsaPassThrough     bool
 	Timeout                 *time.Duration
+	TlsConfig               *tls.Config
 	clientCache             map[string]Client
 	clientCacheLock         sync.RWMutex
 	resourceAreaCache       map[uuid.UUID]ResourceAreaInfo


### PR DESCRIPTION
**Why?**

1. Currently the AzDev Client hides http.client implementation which makes using custom http.client implementations. By exposing this users can use custom http.client implementations which can be used to access AzDev API

**Proposed Solution:**

1. Client is already exposed struct and exposing struct by hiding it's members seems anti-pattern. By exposing them, an implementation can use the custom http client.

**Alternative Solution:**

1. Adding another NewClient function which accepts custom http.client, however method overriding is anti-pattern. Exposing altogether separate function with httpclient argument didn't make sense as we still need another params.