### PR TITLE
Add WithOptions mechanism to Azure DevOps client

### DIFF
--- a/azuredevops/client.go
+++ b/azuredevops/client.go
@@ -50,26 +50,35 @@ var versionSuffix = " (dev)"
 // Base user agent string.  The UserAgent set on the connection will be appended to this.
 var baseUserAgent = "go/" + runtime.Version() + " (" + runtime.GOOS + " " + runtime.GOARCH + ") azure-devops-go-api/" + version + versionSuffix
 
+// NewClient provides an Azure DevOps client
+// and copies the TLS config and timeout from the supplied connection
 func NewClient(connection *Connection, baseUrl string) *Client {
-	var client *http.Client
-
+	httpClient := &http.Client{}
 	if connection.TlsConfig != nil {
-		client = &http.Client{Transport: &http.Transport{TLSClientConfig: connection.TlsConfig}}
-	} else {
-		client = &http.Client{}
+		httpClient.Transport = &http.Transport{TLSClientConfig: connection.TlsConfig}
+	}
+	if connection.Timeout != nil {
+		httpClient.Timeout = *connection.Timeout
 	}
 
-	if connection.Timeout != nil {
-		client.Timeout = *connection.Timeout
-	}
-	return &Client{
+	return NewClientWithOptions(connection, baseUrl, WithHTTPClient(httpClient))
+}
+
+// NewClientWithOptions returns an Azure DevOps client modified by the options
+func NewClientWithOptions(connection *Connection, baseUrl string, options ...ClientOptionFunc) *Client {
+	httpClient := &http.Client{}
+	client := &Client{
 		baseUrl:                 baseUrl,
-		client:                  client,
+		client:                  httpClient,
 		authorization:           connection.AuthorizationString,
 		suppressFedAuthRedirect: connection.SuppressFedAuthRedirect,
 		forceMsaPassThrough:     connection.ForceMsaPassThrough,
 		userAgent:               connection.UserAgent,
 	}
+	for _, fn := range options {
+		fn(client)
+	}
+	return client
 }
 
 type Client struct {

--- a/azuredevops/client_options.go
+++ b/azuredevops/client_options.go
@@ -1,0 +1,15 @@
+package azuredevops
+
+import (
+	"net/http"
+)
+
+// ClientOptionFunc can be used customize a new AzureDevops API client.
+type ClientOptionFunc func(*Client)
+
+// WithHTTPClient can be used to configure a custom HTTP client.
+func WithHTTPClient(httpClient *http.Client) ClientOptionFunc {
+	return func(c *Client) {
+		c.client = httpClient
+	}
+}

--- a/azuredevops/client_test.go
+++ b/azuredevops/client_test.go
@@ -1,0 +1,48 @@
+package azuredevops
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestClient_NewClient(t *testing.T) {
+	tlsConfig := &tls.Config{}
+	timeout := 20 * time.Millisecond
+
+	conn := &Connection{
+		TlsConfig: tlsConfig,
+		Timeout:   &timeout,
+	}
+	baseURL := "localhost"
+	client := NewClient(conn, baseURL)
+	if client.baseUrl != baseURL {
+		t.Errorf("Expected baseURL: %v  Actual baseURL: %v", baseURL, client.baseUrl)
+	}
+	if actualTLSConfig := client.client.Transport.(*http.Transport).TLSClientConfig; actualTLSConfig != tlsConfig {
+		t.Errorf("Expected tlsConfig: %v  Actual tlsConfig: %v", tlsConfig, *actualTLSConfig)
+	}
+}
+
+func TestClient_NewClientWithOptions_WithHTTPClient(t *testing.T) {
+	tlsConfig := &tls.Config{}
+	httpTimeout := 20 * time.Millisecond
+	connTimeout := 40 * time.Millisecond
+
+	conn := &Connection{
+		TlsConfig: tlsConfig,
+		Timeout:   &connTimeout, // will be ignored in favour of httpTimeout
+	}
+
+	httpClient := &http.Client{Timeout: httpTimeout}
+	baseURL := "localhost"
+
+	client := NewClientWithOptions(conn, baseURL, WithHTTPClient(httpClient))
+	if client.baseUrl != baseURL {
+		t.Errorf("Expected baseURL: %v  Actual baseURL: %v", baseURL, client.baseUrl)
+	}
+	if actualHTTPClient := client.client; actualHTTPClient.Timeout != httpClient.Timeout {
+		t.Errorf("Expected httpClient.Timeout: %#v  Actual httpClient.Timeout: %#v", httpClient.Timeout, actualHTTPClient.Timeout)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/microsoft/azure-devops-go-api/issues/52

Adds a new function, `NewClientWithOptions`, to create a new customizable AzureDevOps client.

To close the issue, I've added the first option, `WithHTTPClient`. This way users can supply their own HTTP clients and set the TLS config themselves. 

The current `NewClient` implementation is functionally the same, although I refactored it to use the `NewClientWithOptions` function.

cc/ @nigurr 