### PR TITLE
Fix incorrect value for azuredevops.Time when using in query parameter

### DIFF
--- a/azuredevops/v6/audit/client.go
+++ b/azuredevops/v6/audit/client.go
@@ -121,10 +121,10 @@ func (client *ClientImpl) DownloadLog(ctx context.Context, args DownloadLogArgs)
 	}
 	queryParams.Add("format", *args.Format)
 	if args.StartTime != nil {
-		queryParams.Add("startTime", (*args.StartTime).String())
+		queryParams.Add("startTime", (*args.StartTime).AsQueryParameter())
 	}
 	if args.EndTime != nil {
-		queryParams.Add("endTime", (*args.EndTime).String())
+		queryParams.Add("endTime", (*args.EndTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("b7b98a76-04e8-4f4d-ac72-9d46492caaac")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "6.0-preview.1", nil, queryParams, nil, "", "application/octet-stream", nil)
@@ -189,10 +189,10 @@ type QueryAllStreamsArgs struct {
 func (client *ClientImpl) QueryLog(ctx context.Context, args QueryLogArgs) (*AuditLogQueryResult, error) {
 	queryParams := url.Values{}
 	if args.StartTime != nil {
-		queryParams.Add("startTime", (*args.StartTime).String())
+		queryParams.Add("startTime", (*args.StartTime).AsQueryParameter())
 	}
 	if args.EndTime != nil {
-		queryParams.Add("endTime", (*args.EndTime).String())
+		queryParams.Add("endTime", (*args.EndTime).AsQueryParameter())
 	}
 	if args.BatchSize != nil {
 		queryParams.Add("batchSize", strconv.Itoa(*args.BatchSize))

--- a/azuredevops/v6/build/client.go
+++ b/azuredevops/v6/build/client.go
@@ -1672,10 +1672,10 @@ func (client *ClientImpl) GetBuilds(ctx context.Context, args GetBuildsArgs) (*G
 		queryParams.Add("buildNumber", *args.BuildNumber)
 	}
 	if args.MinTime != nil {
-		queryParams.Add("minTime", (*args.MinTime).String())
+		queryParams.Add("minTime", (*args.MinTime).AsQueryParameter())
 	}
 	if args.MaxTime != nil {
-		queryParams.Add("maxTime", (*args.MaxTime).String())
+		queryParams.Add("maxTime", (*args.MaxTime).AsQueryParameter())
 	}
 	if args.RequestedFor != nil {
 		queryParams.Add("requestedFor", *args.RequestedFor)
@@ -2036,7 +2036,7 @@ func (client *ClientImpl) GetDefinition(ctx context.Context, args GetDefinitionA
 		queryParams.Add("revision", strconv.Itoa(*args.Revision))
 	}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	if args.PropertyFilters != nil {
 		listAsString := strings.Join((*args.PropertyFilters)[:], ",")
@@ -2086,7 +2086,7 @@ func (client *ClientImpl) GetDefinitionMetrics(ctx context.Context, args GetDefi
 
 	queryParams := url.Values{}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("d973b939-0ce0-4fec-91d8-da3940fa1827")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "6.0-preview.1", routeValues, queryParams, nil, "", "application/json", nil)
@@ -2237,7 +2237,7 @@ func (client *ClientImpl) GetDefinitions(ctx context.Context, args GetDefinition
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	if args.DefinitionIds != nil {
 		var stringList []string
@@ -2600,7 +2600,7 @@ func (client *ClientImpl) GetProjectMetrics(ctx context.Context, args GetProject
 
 	queryParams := url.Values{}
 	if args.MinMetricsTime != nil {
-		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).String())
+		queryParams.Add("minMetricsTime", (*args.MinMetricsTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("7433fae7-a6bc-41dc-a6e2-eef9005ce41a")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "6.0-preview.1", routeValues, queryParams, nil, "", "application/json", nil)

--- a/azuredevops/v6/notification/client.go
+++ b/azuredevops/v6/notification/client.go
@@ -289,10 +289,10 @@ func (client *ClientImpl) ListLogs(ctx context.Context, args ListLogsArgs) (*[]I
 
 	queryParams := url.Values{}
 	if args.StartTime != nil {
-		queryParams.Add("startTime", (*args.StartTime).String())
+		queryParams.Add("startTime", (*args.StartTime).AsQueryParameter())
 	}
 	if args.EndTime != nil {
-		queryParams.Add("endTime", (*args.EndTime).String())
+		queryParams.Add("endTime", (*args.EndTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("991842f3-eb16-4aea-ac81-81353ef2b75c")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "6.0", routeValues, queryParams, nil, "", "application/json", nil)

--- a/azuredevops/v6/release/client.go
+++ b/azuredevops/v6/release/client.go
@@ -401,10 +401,10 @@ func (client *ClientImpl) GetDeployments(ctx context.Context, args GetDeployment
 		queryParams.Add("createdBy", *args.CreatedBy)
 	}
 	if args.MinModifiedTime != nil {
-		queryParams.Add("minModifiedTime", (*args.MinModifiedTime).String())
+		queryParams.Add("minModifiedTime", (*args.MinModifiedTime).AsQueryParameter())
 	}
 	if args.MaxModifiedTime != nil {
-		queryParams.Add("maxModifiedTime", (*args.MaxModifiedTime).String())
+		queryParams.Add("maxModifiedTime", (*args.MaxModifiedTime).AsQueryParameter())
 	}
 	if args.DeploymentStatus != nil {
 		queryParams.Add("deploymentStatus", string(*args.DeploymentStatus))
@@ -428,10 +428,10 @@ func (client *ClientImpl) GetDeployments(ctx context.Context, args GetDeployment
 		queryParams.Add("createdFor", *args.CreatedFor)
 	}
 	if args.MinStartedTime != nil {
-		queryParams.Add("minStartedTime", (*args.MinStartedTime).String())
+		queryParams.Add("minStartedTime", (*args.MinStartedTime).AsQueryParameter())
 	}
 	if args.MaxStartedTime != nil {
-		queryParams.Add("maxStartedTime", (*args.MaxStartedTime).String())
+		queryParams.Add("maxStartedTime", (*args.MaxStartedTime).AsQueryParameter())
 	}
 	if args.SourceBranch != nil {
 		queryParams.Add("sourceBranch", *args.SourceBranch)
@@ -951,10 +951,10 @@ func (client *ClientImpl) GetReleases(ctx context.Context, args GetReleasesArgs)
 		queryParams.Add("environmentStatusFilter", strconv.Itoa(*args.EnvironmentStatusFilter))
 	}
 	if args.MinCreatedTime != nil {
-		queryParams.Add("minCreatedTime", (*args.MinCreatedTime).String())
+		queryParams.Add("minCreatedTime", (*args.MinCreatedTime).AsQueryParameter())
 	}
 	if args.MaxCreatedTime != nil {
-		queryParams.Add("maxCreatedTime", (*args.MaxCreatedTime).String())
+		queryParams.Add("maxCreatedTime", (*args.MaxCreatedTime).AsQueryParameter())
 	}
 	if args.QueryOrder != nil {
 		queryParams.Add("queryOrder", string(*args.QueryOrder))

--- a/azuredevops/v6/workitemtracking/client.go
+++ b/azuredevops/v6/workitemtracking/client.go
@@ -1756,7 +1756,7 @@ func (client *ClientImpl) GetReportingLinksByLinkType(ctx context.Context, args 
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.StartDateTime != nil {
-		queryParams.Add("startDateTime", (*args.StartDateTime).String())
+		queryParams.Add("startDateTime", (*args.StartDateTime).AsQueryParameter())
 	}
 	locationId, _ := uuid.Parse("b5b5b6d0-0308-40a1-b3f4-b9bb3c66878f")
 	resp, err := client.Client.Send(ctx, http.MethodGet, locationId, "6.0", routeValues, queryParams, nil, "", "application/json", nil)
@@ -2905,7 +2905,7 @@ func (client *ClientImpl) ReadReportingRevisionsGet(ctx context.Context, args Re
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.StartDateTime != nil {
-		queryParams.Add("startDateTime", (*args.StartDateTime).String())
+		queryParams.Add("startDateTime", (*args.StartDateTime).AsQueryParameter())
 	}
 	if args.IncludeIdentityRef != nil {
 		queryParams.Add("includeIdentityRef", strconv.FormatBool(*args.IncludeIdentityRef))
@@ -2982,7 +2982,7 @@ func (client *ClientImpl) ReadReportingRevisionsPost(ctx context.Context, args R
 		queryParams.Add("continuationToken", *args.ContinuationToken)
 	}
 	if args.StartDateTime != nil {
-		queryParams.Add("startDateTime", (*args.StartDateTime).String())
+		queryParams.Add("startDateTime", (*args.StartDateTime).AsQueryParameter())
 	}
 	if args.Expand != nil {
 		queryParams.Add("$expand", string(*args.Expand))


### PR DESCRIPTION
same fix from:
https://github.com/microsoft/azure-devops-go-api/pull/81/files

but for v6 sub folder this time.