### PR TITLE
Fix environment k8s resource creation error

### DIFF
--- a/azuredevops/v6/taskagent/client.go
+++ b/azuredevops/v6/taskagent/client.go
@@ -381,7 +381,7 @@ func (client *ClientImpl) AddKubernetesResource(ctx context.Context, args AddKub
 // Arguments for the AddKubernetesResource function
 type AddKubernetesResourceArgs struct {
 	// (required)
-	CreateParameters *KubernetesResourceCreateParameters
+	CreateParameters *KubernetesResourceCreateParametersExistingEndpoint
 	// (required) Project ID or project name
 	Project *string
 	// (required)


### PR DESCRIPTION
`serviceEndpointId` is the required parameter to create new env k8s. Replace `KubernetesResourceCreateParameters` with `KubernetesResourceCreateParametersExistingEndpoint`

Issue: https://github.com/microsoft/azure-devops-go-api/issues/116

@nechvatalp  this is a bug fix