### PR TITLE
Fix response to return valid response body in GetPullRequestProperties

### DIFF
--- a/azuredevops/git/client.go
+++ b/azuredevops/git/client.go
@@ -3873,7 +3873,7 @@ func (client *ClientImpl) GetPullRequestProperties(ctx context.Context, args Get
 	}
 
 	var responseValue interface{}
-	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	err = client.Client.UnmarshalBody(resp, &responseValue)
 	return responseValue, err
 }
 

--- a/azuredevops/git/client.go
+++ b/azuredevops/git/client.go
@@ -3873,7 +3873,7 @@ func (client *ClientImpl) GetPullRequestProperties(ctx context.Context, args Get
 	}
 
 	var responseValue interface{}
-	err = client.Client.UnmarshalBody(resp, responseValue)
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
 	return responseValue, err
 }
 

--- a/azuredevops/v6/git/client.go
+++ b/azuredevops/v6/git/client.go
@@ -3933,7 +3933,7 @@ func (client *ClientImpl) GetPullRequestProperties(ctx context.Context, args Get
 	}
 
 	var responseValue interface{}
-	err = client.Client.UnmarshalBody(resp, responseValue)
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
 	return responseValue, err
 }
 

--- a/azuredevops/v6/git/client.go
+++ b/azuredevops/v6/git/client.go
@@ -3933,7 +3933,7 @@ func (client *ClientImpl) GetPullRequestProperties(ctx context.Context, args Get
 	}
 
 	var responseValue interface{}
-	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	err = client.Client.UnmarshalBody(resp, &responseValue)
 	return responseValue, err
 }
 

--- a/azuredevops/v7/git/client.go
+++ b/azuredevops/v7/git/client.go
@@ -3973,7 +3973,7 @@ func (client *ClientImpl) GetPullRequestProperties(ctx context.Context, args Get
 	}
 
 	var responseValue interface{}
-	err = client.Client.UnmarshalBody(resp, responseValue)
+	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
 	return responseValue, err
 }
 

--- a/azuredevops/v7/git/client.go
+++ b/azuredevops/v7/git/client.go
@@ -3973,7 +3973,7 @@ func (client *ClientImpl) GetPullRequestProperties(ctx context.Context, args Get
 	}
 
 	var responseValue interface{}
-	err = client.Client.UnmarshalCollectionBody(resp, &responseValue)
+	err = client.Client.UnmarshalBody(resp, &responseValue)
 	return responseValue, err
 }
 


### PR DESCRIPTION
When call GetPullRequestProperties it returns empty body, so change to use UnmarshalCollectionBody function to return real body.