### PR TITLE
fix: provide json.Unmarshal with a pointer

### DIFF
--- a/azuredevops/v7/taskagent/client.go
+++ b/azuredevops/v7/taskagent/client.go
@@ -1888,7 +1888,7 @@ func (client *ClientImpl) GetYamlSchema(ctx context.Context, args GetYamlSchemaA
 	}
 
 	var responseValue interface{}
-	err = client.Client.UnmarshalBody(resp, responseValue)
+	err = client.Client.UnmarshalBody(resp, &responseValue)
 	return responseValue, err
 }
 


### PR DESCRIPTION
Ensure a pointer is given to `json.Unmarshal`, otherwise `taskagent.getYamlSchema()` always yields `nil`. 