### PR TITLE
Add group deleted flag

### DIFF
--- a/azuredevops/v7/graph/models.go
+++ b/azuredevops/v7/graph/models.go
@@ -87,6 +87,8 @@ type GraphGroup struct {
 	PrincipalName *string `json:"principalName,omitempty"`
 	// A short phrase to help human readers disambiguate groups with similar names
 	Description *string `json:"description,omitempty"`
+	// Whether the group has been deleted
+	IsDeleted *bool `json:"isDeleted,omitempty"`
 }
 
 // Do not attempt to use this type to create a new group. This type does not contain sufficient fields to create a new group.


### PR DESCRIPTION
The service returns a flag indicating whether the group has been deleted.  However, this property is not documented in either the API doc or the SDK.
![image](https://github.com/user-attachments/assets/75272ed4-0d54-4ed0-8486-d6bdd0a3317d)

ADO issue: https://github.com/microsoft/terraform-provider-azuredevops/issues/1154
