### PR TITLE
Fix build with Go 1.24

### DIFF
--- a/azuredevops/models_test.go
+++ b/azuredevops/models_test.go
@@ -27,7 +27,7 @@ func TestModels_Unmarshal_Time(t *testing.T) {
 
 	parsedTime, err := time.Parse(time.RFC3339Nano, "2019-09-01T00:07:26Z")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	if testModel.Time2.Time != parsedTime {
 		t.Errorf("Expected time: %v  Actual time: %v", parsedTime, testModel.Time2.Time)
@@ -46,13 +46,13 @@ func TestModels_Marshal_Unmarshal_Time(t *testing.T) {
 	testModel1.Time1.Time = time.Now()
 	b, err := json.Marshal(testModel1)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	testModel2 := TestModel{}
 	err = json.Unmarshal(b, &testModel2)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	if testModel1.Time1 != testModel1.Time1 {

--- a/azuredevops/v6/models_test.go
+++ b/azuredevops/v6/models_test.go
@@ -27,7 +27,7 @@ func TestModels_Unmarshal_Time(t *testing.T) {
 
 	parsedTime, err := time.Parse(time.RFC3339Nano, "2019-09-01T00:07:26Z")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	if testModel.Time2.Time != parsedTime {
 		t.Errorf("Expected time: %v  Actual time: %v", parsedTime, testModel.Time2.Time)
@@ -46,13 +46,13 @@ func TestModels_Marshal_Unmarshal_Time(t *testing.T) {
 	testModel1.Time1.Time = time.Now()
 	b, err := json.Marshal(testModel1)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	testModel2 := TestModel{}
 	err = json.Unmarshal(b, &testModel2)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	if testModel1.Time1 != testModel1.Time1 {

--- a/azuredevops/v7/models_test.go
+++ b/azuredevops/v7/models_test.go
@@ -27,7 +27,7 @@ func TestModels_Unmarshal_Time(t *testing.T) {
 
 	parsedTime, err := time.Parse(time.RFC3339Nano, "2019-09-01T00:07:26Z")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	if testModel.Time2.Time != parsedTime {
 		t.Errorf("Expected time: %v  Actual time: %v", parsedTime, testModel.Time2.Time)
@@ -46,13 +46,13 @@ func TestModels_Marshal_Unmarshal_Time(t *testing.T) {
 	testModel1.Time1.Time = time.Now()
 	b, err := json.Marshal(testModel1)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	testModel2 := TestModel{}
 	err = json.Unmarshal(b, &testModel2)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	if testModel1.Time1 != testModel1.Time1 {


### PR DESCRIPTION
Go 1.24 provides stricter checking that forbids passing a variable as a format string to Printf-like functions with no other arguments. Remove instances of this. See also:

https://tip.golang.org/doc/go1.24#vet